### PR TITLE
fix: Resolve Circular Dependency in Module Imports

### DIFF
--- a/electron/modules/discord-rpc.js
+++ b/electron/modules/discord-rpc.js
@@ -4,7 +4,6 @@
  */
 
 const { Client } = require("discord-rpc");
-const { getSettingsManager } = require("./settings");
 const { clientId, isDev } = require("./config");
 
 let rpc = null;
@@ -50,6 +49,7 @@ function initializeDiscordRPC() {
     return;
   }
 
+  const { getSettingsManager } = require("./settings");
   const settingsManager = getSettingsManager();
   const settings = settingsManager.getSettings();
   if (settings.rpcEnabled === false) {

--- a/electron/modules/settings.js
+++ b/electron/modules/settings.js
@@ -7,7 +7,6 @@ const fs = require("fs-extra");
 const path = require("path");
 const { app, ipcMain } = require("electron");
 const { encrypt, decrypt } = require("./encryption");
-const { initializeDiscordRPC, destroyDiscordRPC } = require("./discord-rpc");
 
 class SettingsManager {
   constructor() {
@@ -277,6 +276,8 @@ function registerSettingsHandlers() {
       event.sender.send("settings-changed", manager.getSettings());
       // Handle Discord RPC toggle immediately
       if (key === "rpcEnabled") {
+        const { initializeDiscordRPC, destroyDiscordRPC } = require("./discord-rpc");
+        
         if (value) {
           initializeDiscordRPC();
         } else {


### PR DESCRIPTION
This PR fixes a circular dependency issue between the settings and discord-rpc modules. Currently, discord-rpc requires settings at the top level, while settings require discord-rpc, leading to an error during the initialization phase.