### PR TITLE
Revert: remove Python in umu launcher comand

### DIFF
--- a/.github/workflows/test_gamehandler.yml
+++ b/.github/workflows/test_gamehandler.yml
@@ -1,0 +1,37 @@
+name: Test Build GameHandler
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create build venv
+        run: python3 -m venv .build_venv
+
+      - name: Install PyInstaller
+        run: .build_venv/bin/pip install --quiet pyinstaller
+
+      - name: Install GameHandler dependencies
+        run: .build_venv/bin/pip install --quiet -r binaries/AscendaraGameHandler/requirements.txt
+
+      - name: Compile AscendaraGameHandler
+        run: |
+          mkdir -p binaries/AscendaraGameHandler/dist
+          .build_venv/bin/python3 -m PyInstaller \
+            --onefile \
+            --noconfirm \
+            --name AscendaraGameHandler \
+            --distpath binaries/AscendaraGameHandler/dist \
+            --workpath binaries/AscendaraGameHandler/dist/build_tmp \
+            --specpath binaries/AscendaraGameHandler/dist/spec_tmp \
+            binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: AscendaraGameHandler-ubuntu-latest
+          path: binaries/AscendaraGameHandler/dist/AscendaraGameHandler

--- a/binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
+++ b/binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
@@ -260,26 +260,12 @@ def launch_with_wine_isolated(exe_path, linux_config, game_launch_cmd=None):
         logging.error(f"[Wine] Failed to launch: {e}", exc_info=True)
         return None
 
-def get_python_executable():
-    python_path = shutil.which("python3")
-    
-    if not python_path:
-        # Fallback
-        python_path = shutil.which("python")
-        
-    if not python_path:
-        logging.error("[UMU] No Python interpreter was found on the system.")
-        return None
-        
-    return python_path
-
 def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     """
     Launch a Windows executable using umu-run.
     Equivalent to: GAMEID=umu-xxxx PROTONPATH=/path/to/proton WINEPREFIX=/path umu-run game.exe
     """
     umu_bin = linux_config["runner_path"]  # absolute path to umu-run
-    python_bin = get_python_executable()
 
     if not os.path.exists(umu_bin):
         logging.error(f"[UMU] umu-run not found at: {umu_bin}")
@@ -291,10 +277,6 @@ def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     os.makedirs(prefix_path, exist_ok=True)
 
     env = os.environ.copy()
-    # clean env
-    for var in ["PYTHONPATH", "PYTHONHOME", "LD_LIBRARY_PATH"]:
-        env.pop(var, None)
-
     env["GAMEID"] = linux_config.get("umu_id") or "umu-default"
     env["WINEPREFIX"] = prefix_path
     env["STEAM_COMPAT_DATA_PATH"] = linux_config["compat_data"]
@@ -306,7 +288,7 @@ def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     if linux_config.get("steam_path"):
         env["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = linux_config["steam_path"]
 
-    cmd = [python_bin, umu_bin, exe_path]
+    cmd = [umu_bin, exe_path]
     if game_launch_cmd:
         cmd.extend(game_launch_cmd.split())
 
@@ -315,7 +297,6 @@ def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     logging.info(f"[UMU] Command: {' '.join(cmd)}")
     logging.info(f"[UMU] GAMEID={env['GAMEID']}, WINEPREFIX={prefix_path}")
     logging.info(f"[UMU] PROTONPATH={env.get('PROTONPATH', '(auto)')}")
-    logging.info(f"[UMU] Using Python: {python_bin}")
 
     try:
         process = subprocess.Popen(

--- a/binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
+++ b/binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
@@ -169,7 +169,7 @@ def launch_with_proton(exe_path, linux_config, game_launch_cmd=None):
 
     os.chmod(proton_script, 0o755)
 
-    env = os.environ.copy()
+    env = _clean_pyinstaller_env(os.environ.copy())
     env["STEAM_COMPAT_DATA_PATH"] = linux_config["compat_data"]
 
     if linux_config.get("steam_path"):
@@ -223,7 +223,7 @@ def launch_with_wine_isolated(exe_path, linux_config, game_launch_cmd=None):
     prefix_path = os.path.join(linux_config["compat_data"], "pfx")
     os.makedirs(prefix_path, exist_ok=True)
 
-    env = os.environ.copy()
+    env = _clean_pyinstaller_env(os.environ.copy())
     env["WINEPREFIX"] = prefix_path
     env["WINEDLLOVERRIDES"] = "winemenubuilder.exe=d"
 
@@ -260,6 +260,16 @@ def launch_with_wine_isolated(exe_path, linux_config, game_launch_cmd=None):
         logging.error(f"[Wine] Failed to launch: {e}", exc_info=True)
         return None
 
+def _clean_pyinstaller_env(env):
+    for var in ('LD_LIBRARY_PATH', 'LD_PRELOAD', 'PYTHONPATH', 'PYTHONHOME'):
+        orig = env.get(var + '_ORIG')
+        if orig is not None:
+            env[var] = orig
+            del env[var + '_ORIG']
+        else:
+            env.pop(var, None)
+    return env
+
 def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     """
     Launch a Windows executable using umu-run.
@@ -276,7 +286,7 @@ def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     prefix_path = linux_config["compat_data"]
     os.makedirs(prefix_path, exist_ok=True)
 
-    env = os.environ.copy()
+    env = _clean_pyinstaller_env(os.environ.copy())
     env["GAMEID"] = linux_config.get("umu_id") or "umu-default"
     env["WINEPREFIX"] = prefix_path
     env["STEAM_COMPAT_DATA_PATH"] = linux_config["compat_data"]


### PR DESCRIPTION
Removed Python from umu launcher command as it was not the source of the issue. This PR keeps the fix for the WINEPREFIX path.