### PR TITLE
fix: resolve ludusavi game name alias for cloud upload and backup listing

### DIFF
--- a/src/components/GamesBackupDialog.jsx
+++ b/src/components/GamesBackupDialog.jsx
@@ -697,13 +697,19 @@ const GamesBackupDialog = ({ game, open, onOpenChange, bigPictureMode = false })
       const data = result.data;
       let gameBackups = [];
 
-      if (data?.games?.[gameName]?.backups) {
-        gameBackups = data.games[gameName].backups.map(backup => ({
+      const resolvedKey = data?.games
+        ? Object.keys(data.games).find(k =>
+            k === gameName || k.toLowerCase().startsWith(gameName.toLowerCase())
+          )
+        : null;
+
+      if (resolvedKey && data.games[resolvedKey].backups) {
+        gameBackups = data.games[resolvedKey].backups.map(backup => ({
           name: backup.name,
           timestamp: backup.when,
           os: backup.os,
           locked: backup.locked,
-          path: data.games[gameName].backupPath,
+          path: data.games[resolvedKey].backupPath,
           isLocal: true,
         }));
 

--- a/src/services/cloudBackupService.js
+++ b/src/services/cloudBackupService.js
@@ -20,7 +20,15 @@ export const uploadBackupToCloud = async (gameName, settings, user, userData) =>
   try {
 
     // 1. Get latest LOCAL backup
-    const gameBackupFolder = `${backupLocation}/${gameName}`;
+    const listResult = await window.electron.ludusavi("list-backups", gameName);
+    const gamesData = listResult?.data?.games;
+    const resolvedKey = gamesData && Object.keys(gamesData).find(k =>
+      k === gameName || k.toLowerCase().startsWith(gameName.toLowerCase())
+    );
+    const gameBackupFolder = resolvedKey
+      ? gamesData[resolvedKey].backupPath
+      : `${backupLocation}/${gameName}`;
+
     const backupFiles = await window.electron.listBackupFiles(gameBackupFolder);
 
     if (!backupFiles || backupFiles.length === 0) {


### PR DESCRIPTION
Ludusavi resolves game name aliases to their full title (e.g. "Vampire Crawlers" --> "Vampire Crawlers: The Turbo Wildcard from Vampire Survivors"). This resolved name is used both as the JSON key in API responses and as the backup folder name on disk.

Fixed by using the first key returned by ludusavi in the API response instead of the original game name.