### PR TITLE
Fix: Resolve infinite Discord RPC retry loop

### DIFF
--- a/electron/modules/discord-rpc.js
+++ b/electron/modules/discord-rpc.js
@@ -28,7 +28,6 @@ function destroyDiscordRPC() {
     } finally {
       rpc = null;
       rpcIsConnected = false;
-      rpcConnectionAttempts = 0;
       currentlyPlayingGame = null;
     }
     console.log("Discord RPC has been destroyed");


### PR DESCRIPTION
This PR fixes an issue where the discord RPC connection would enter an infinite retry loop due to the connection attempt counter being reset on every cleanup.