### PR TITLE
Feat: replace hardcoded text and translated titles

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -3010,30 +3010,29 @@ function Settings() {
                   {/* ── UMU Section ── */}
                   <div className="border-t border-border pt-6 space-y-4">
                     <h4 className="text-sm font-medium text-foreground">
-                      {t("settings.linuxCompat.umu.sectionTitle")}
+                      UMU Launcher & UMU-Proton
                     </h4>
                     <p className="text-xs text-muted-foreground">
-                      UMU-Launcher runs games through Steam's Linux Runtime container and applies
-                      Protonfixes automatically. UMU-Proton is the recommended Proton build.
+                      {t("settings.linuxCompat.infoBoxUmuLauncher")}
                     </p>
 
                     <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                       {/* UMU Launcher */}
                       <div className="rounded-lg border border-border bg-muted/30 p-4 space-y-3">
                         <div className="flex items-center justify-between">
-                          <span className="text-sm font-medium">{t("settings.linuxCompat.umu.launcher.title")}</span>
+                          <span className="text-sm font-medium">UMU Launcher</span>
                           {umuInstalled ? (
                             <span className="flex items-center gap-1 rounded bg-green-500/20 px-2 py-0.5 text-xs font-semibold text-green-600">
-                              <FileCheck2 className="h-3 w-3" /> Installed
+                              <FileCheck2 className="h-3 w-3" /> {t("common.installed")}
                             </span>
                           ) : (
                             <span className="flex items-center gap-1 rounded bg-red-500/20 px-2 py-0.5 text-xs font-semibold text-red-500">
-                              <AlertTriangle className="h-3 w-3" /> Missing
+                              <AlertTriangle className="h-3 w-3" /> {t("common.missing")}
                             </span>
                           )}
                         </div>
                         <p className="text-xs text-muted-foreground">
-                          Required to launch games without Steam via the Sniper runtime.
+                          {t("settings.linuxCompat.umuRequired")}
                         </p>
                         <div className="flex items-center gap-2">
                           <Button
@@ -3057,18 +3056,18 @@ function Settings() {
                             }}
                           >
                             {isDownloadingUmuLauncher ? (
-                              <><Loader className="h-3 w-3 animate-spin" /> Installing...</>
+                              <><Loader className="h-3 w-3 animate-spin" /> {t("common.installing")}</>
                             ) : umuInstalled ? (
-                              <><RefreshCw className="h-3 w-3" /> Reinstall/Update</>
+                              <><RefreshCw className="h-3 w-3" /> {t("settings.linuxCompat.reinstallUpdate")}</>
                             ) : (
-                              <><Download className="h-3 w-3" /> Install</>
+                              <><Download className="h-3 w-3" /> {t("common.install")}</>
                             )}
                           </Button>
                           <button
                             onClick={() => window.electron.openURL("https://github.com/Open-Wine-Components/umu-launcher")}
                             className="text-xs text-muted-foreground hover:text-primary underline"
                           >
-                            {t("settings.linuxCompat.umu.launcher.github")}
+                            GitHub
                           </button>
                         </div>
                       </div>
@@ -3076,23 +3075,23 @@ function Settings() {
                       {/* UMU Proton */}
                       <div className="rounded-lg border border-border bg-muted/30 p-4 space-y-3">
                         <div className="flex items-center justify-between">
-                          <span className="text-sm font-medium">{t("settings.linuxCompat.umu.proton.title")}</span>
+                          <span className="text-sm font-medium">UMU-Proton</span>
                           {umuProtonInfo?.alreadyInstalled ? (
                             <span className="flex items-center gap-1 rounded bg-green-500/20 px-2 py-0.5 text-xs font-semibold text-green-600">
                               <FileCheck2 className="h-3 w-3" /> {umuProtonInfo.name}
                             </span>
                           ) : umuProtonInfo?.updateAvailable ? (
                             <span className="flex items-center gap-1 rounded bg-blue-500/20 px-2 py-0.5 text-xs font-semibold text-blue-500">
-                              <FolderSync className="h-3 w-3" /> Update available
+                              <FolderSync className="h-3 w-3" /> {t("settings.linuxCompat.updateAvailableUmu")}
                             </span>
                           ) : (
                             <span className="flex items-center gap-1 rounded bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground">
-                              Not installed
+                              {t("settings.linuxCompat.notInstalled")}
                             </span>
                           )}
                         </div>
                         <p className="text-xs text-muted-foreground">
-                          Recommended Proton build with built-in Protonfixes support.
+                          {t("settings.linuxCompat.infoBoxUmuProton")}
                           {umuProtonInfo?.sizeFormatted && ` Latest: ${umuProtonInfo.name} (${umuProtonInfo.sizeFormatted})`}
                         </p>
                         <div className="flex items-center gap-2">
@@ -3121,13 +3120,13 @@ function Settings() {
                             }}
                           >
                             {isDownloadingUmuProton ? (
-                              <><Loader className="h-3 w-3 animate-spin" /> Installing...</>
+                              <><Loader className="h-3 w-3 animate-spin" /> {t("common.installing")}</>
                             ) : umuProtonInfo?.alreadyInstalled ? (
-                              <><FolderSync className="h-3 w-3" /> Reinstall</>
+                              <><FolderSync className="h-3 w-3" /> {t("settings.linuxCompat.reinstall")}</>
                             ) : umuProtonInfo?.updateAvailable ? (
-                              <><Download className="h-3 w-3" /> Update</>
+                              <><Download className="h-3 w-3" /> {t("settings.linuxCompat.update")}</>
                             ) : (
-                              <><Download className="h-3 w-3" /> Install</>
+                              <><Download className="h-3 w-3" /> {t("common.install")}</>
                             )}
                           </Button>
                           <Button
@@ -3153,29 +3152,29 @@ function Settings() {
                             ) : (
                               <FolderSync className="h-3 w-3" />
                             )}
-                            Check
+                            {t("settings.linuxCompat.checkForUpdates")}
                           </Button>
                         </div>
 
                         {umuProtonUpdateStatus === "up-to-date" && (
                           <p className="text-xs text-green-500 flex items-center gap-1">
-                            <FileCheck2 className="h-3 w-3" /> Up to date
+                            <FileCheck2 className="h-3 w-3" /> {t("settings.linuxCompat.upToDate")}
                           </p>
                         )}
                         {umuProtonUpdateStatus === "update-available" && (
                           <p className="text-xs text-blue-500 flex items-center gap-1">
-                            <AlertTriangle className="h-3 w-3" /> Update available: {umuProtonInfo?.latestVersion}
+                            <AlertTriangle className="h-3 w-3" /> {t("settings.linuxCompat.updateAvailableUmu")}: {umuProtonInfo?.latestVersion}
                           </p>
                         )}
                       </div>
                     </div>
 
-                    {/* Warning si UMU pas installé */}
+                    {/* Warning if UMU not installed */}
                     {!umuInstalled && (
                       <div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 p-3">
                         <AlertTriangle className="h-4 w-4 text-yellow-500 mt-0.5 shrink-0" />
                         <p className="text-xs text-yellow-600 dark:text-yellow-400">
-                          UMU Launcher is not installed. Games may crash without it. Install it above to enable automatic dependency fixes via Protonfixes.
+                          {t("gameScreen.umuLauncherNotInstalled")}
                         </p>
                       </div>
                     )}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -2497,6 +2497,7 @@
       "update": "Update",
       "updateAvailable": "Update available: <strong>{{version}}</strong>",
       "updateAvailableCurrent": "(current: {{version}})",
+      "updateAvailableUmu": "Update available",
       "updateProtonGE": "Update Proton-GE"
     },
     "loadingSettings": "Loading your settings",


### PR DESCRIPTION
This PR reintroduce all translations for the linux compatibility section in the settings page.
Also fixes the titles not being translated by re-hardcoding them.