### PR TITLE
Feat/linux auto vcredist

### DIFF
--- a/binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
+++ b/binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
@@ -272,6 +272,80 @@ def _clean_pyinstaller_env(env):
             env.pop(var, None)
     return env
 
+def install_vcredist(prefix_path, env, proton_path=None):
+    """Install Visual C++ redistributables (x86 + x64) using wine directly"""
+    
+    vcredist_marker = os.path.join(prefix_path, ".vcredist_installed")
+    if os.path.exists(vcredist_marker):
+        logging.info("[VCREDIST] Already installed, skipping")
+        return
+
+    # Find wine64 and wine (for x86) from proton or system
+    wine64_bin = None
+    wine32_bin = None
+    if proton_path:
+        wine64_bin = os.path.join(proton_path, "files", "bin", "wine64")
+        wine32_bin = os.path.join(proton_path, "files", "bin", "wine")
+        if not os.path.exists(wine64_bin):
+            wine64_bin = None
+        if not os.path.exists(wine32_bin):
+            wine32_bin = None
+    if not wine64_bin:
+        wine64_bin = shutil.which("wine64") or shutil.which("wine")
+    if not wine32_bin:
+        wine32_bin = shutil.which("wine")
+    
+    if not wine32_bin:
+        logging.warning("[VCREDIST] No wine binary found, skipping vcredist install")
+        return
+
+    # Microsoft URLs - x86 AND x64
+    installers = [
+        ("vc_redist.x64.exe", "https://aka.ms/vc14/vc_redist.x64.exe", wine64_bin or wine32_bin),
+        ("vc_redist.x86.exe", "https://aka.ms/vc14/vc_redist.x86.exe", wine32_bin),
+    ]
+
+    all_success = True
+    for filename, url, wine_bin in installers:
+        dest_path = os.path.join(prefix_path, filename)
+        
+        logging.info(f"[VCREDIST] Downloading {filename}...")
+        try:
+            import urllib.request
+            urllib.request.urlretrieve(url, dest_path)
+            logging.info(f"[VCREDIST] Download complete: {filename}")
+        except Exception as e:
+            logging.error(f"[VCREDIST] Download failed for {filename}: {e}")
+            all_success = False
+            continue
+
+        logging.info(f"[VCREDIST] Installing {filename} silently...")
+        try:
+            result = subprocess.run(
+                [wine_bin, dest_path, "/install", "/quiet", "/norestart"],
+                env=env,
+                timeout=120,
+                capture_output=True
+            )
+            if result.returncode in (0, 3010):
+                logging.info(f"[VCREDIST] {filename} installed successfully")
+            else:
+                logging.error(f"[VCREDIST] {filename} failed with code: {result.returncode}")
+                all_success = False
+        except Exception as e:
+            logging.error(f"[VCREDIST] Install error for {filename}: {e}")
+            all_success = False
+        finally:
+            if os.path.exists(dest_path):
+                os.remove(dest_path)
+
+    # Only create marker if both succeeded
+    if all_success:
+        open(vcredist_marker, 'w').close()
+        logging.info("[VCREDIST] All redistributables installed successfully")
+    else:
+        logging.warning("[VCREDIST] Some redistributables failed to install, will retry next launch")
+
 def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     """
     Launch a Windows executable using umu-run.
@@ -303,6 +377,8 @@ def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     cmd = [umu_bin, exe_path]
     if game_launch_cmd:
         cmd.extend(game_launch_cmd.split())
+
+    install_vcredist(prefix_path, env, proton_path=linux_config.get("proton_path"))
 
     game_dir = os.path.dirname(exe_path)
 

--- a/binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
+++ b/binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
@@ -272,7 +272,7 @@ def _clean_pyinstaller_env(env):
             env.pop(var, None)
     return env
 
-def install_vcredist(prefix_path, env, proton_path=None):
+def install_vcredist(prefix_path, proton_path=None):
     """Install Visual C++ redistributables (x86 + x64) using wine directly"""
     
     vcredist_marker = os.path.join(prefix_path, ".vcredist_installed")
@@ -320,10 +320,20 @@ def install_vcredist(prefix_path, env, proton_path=None):
             continue
 
         logging.info(f"[VCREDIST] Installing {filename} silently...")
+
+        wine_env = {
+            "WINEPREFIX": prefix_path,
+            "HOME": os.environ.get("HOME", ""),
+            "PATH": os.environ.get("PATH", ""),
+            "DISPLAY": os.environ.get("DISPLAY", ":0"),
+            "WINEDLLOVERRIDES": "winemenubuilder.exe=d",
+            "WINEDEBUG": "-all",  # Supprime les messages debug wine
+        }
+
         try:
             result = subprocess.run(
                 [wine_bin, dest_path, "/install", "/quiet", "/norestart"],
-                env=env,
+                env=wine_env,
                 timeout=120,
                 capture_output=True
             )
@@ -378,7 +388,7 @@ def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     if game_launch_cmd:
         cmd.extend(game_launch_cmd.split())
 
-    install_vcredist(prefix_path, env, proton_path=linux_config.get("proton_path"))
+    install_vcredist(prefix_path, proton_path=linux_config.get("proton_path"))
 
     game_dir = os.path.dirname(exe_path)
 
@@ -803,7 +813,7 @@ def execute(game_path, is_custom_game, admin, is_shortcut=False, use_ludusavi=Fa
             logging.error(f"Game not found in games.json for executable path: {exe_path}")
             logging.info("[EXIT] execute due to missing game_entry for custom game")
             return
-        game_name = game_entry.get("name", os.path.basename(os.path.dirname(exe_path)))
+        game_name = game_entry.get("game") or game_entry.get("name") or os.path.basename(os.path.dirname(exe_path))
     
     logging.info(f"Resolved game_dir: {os.path.dirname(exe_path)}, exe_path: {exe_path}")
 

--- a/binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
+++ b/binaries/AscendaraGameHandler/src/AscendaraGameHandler.py
@@ -272,41 +272,26 @@ def _clean_pyinstaller_env(env):
             env.pop(var, None)
     return env
 
-def install_vcredist(prefix_path, proton_path=None):
-    """Install Visual C++ redistributables (x86 + x64) using wine directly"""
+def install_vcredist(prefix_path, env, umu_bin=None):
+    """Install Visual C++ redistributables (x86 + x64) using umu-run directly"""
     
     vcredist_marker = os.path.join(prefix_path, ".vcredist_installed")
     if os.path.exists(vcredist_marker):
         logging.info("[VCREDIST] Already installed, skipping")
         return
 
-    # Find wine64 and wine (for x86) from proton or system
-    wine64_bin = None
-    wine32_bin = None
-    if proton_path:
-        wine64_bin = os.path.join(proton_path, "files", "bin", "wine64")
-        wine32_bin = os.path.join(proton_path, "files", "bin", "wine")
-        if not os.path.exists(wine64_bin):
-            wine64_bin = None
-        if not os.path.exists(wine32_bin):
-            wine32_bin = None
-    if not wine64_bin:
-        wine64_bin = shutil.which("wine64") or shutil.which("wine")
-    if not wine32_bin:
-        wine32_bin = shutil.which("wine")
-    
-    if not wine32_bin:
-        logging.warning("[VCREDIST] No wine binary found, skipping vcredist install")
+    if not umu_bin:
+        logging.warning("[VCREDIST] No umu-run binary, skipping vcredist install")
         return
 
     # Microsoft URLs - x86 AND x64
     installers = [
-        ("vc_redist.x64.exe", "https://aka.ms/vc14/vc_redist.x64.exe", wine64_bin or wine32_bin),
-        ("vc_redist.x86.exe", "https://aka.ms/vc14/vc_redist.x86.exe", wine32_bin),
+        ("vc_redist.x64.exe", "https://aka.ms/vc14/vc_redist.x64.exe"),
+        ("vc_redist.x86.exe", "https://aka.ms/vc14/vc_redist.x86.exe"),
     ]
 
     all_success = True
-    for filename, url, wine_bin in installers:
+    for filename, url in installers:
         dest_path = os.path.join(prefix_path, filename)
         
         logging.info(f"[VCREDIST] Downloading {filename}...")
@@ -319,24 +304,24 @@ def install_vcredist(prefix_path, proton_path=None):
             all_success = False
             continue
 
-        logging.info(f"[VCREDIST] Installing {filename} silently...")
-
-        wine_env = {
-            "WINEPREFIX": prefix_path,
-            "HOME": os.environ.get("HOME", ""),
-            "PATH": os.environ.get("PATH", ""),
-            "DISPLAY": os.environ.get("DISPLAY", ":0"),
-            "WINEDLLOVERRIDES": "winemenubuilder.exe=d",
-            "WINEDEBUG": "-all",  # Supprime les messages debug wine
-        }
-
+        logging.info(f"[VCREDIST] Installing {filename} via umu-run...")
         try:
+            # Use umu-run to launch the exe
+            install_env = env.copy()
             result = subprocess.run(
-                [wine_bin, dest_path, "/install", "/quiet", "/norestart"],
-                env=wine_env,
+                [umu_bin, dest_path, "/install", "/quiet", "/norestart"],
+                env=install_env,
                 timeout=120,
-                capture_output=True
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
             )
+            stdout = result.stdout.decode('utf-8', errors='replace').strip()
+            stderr = result.stderr.decode('utf-8', errors='replace').strip()
+            if stdout:
+                logging.info(f"[VCREDIST] stdout: {stdout}")
+            if stderr:
+                logging.info(f"[VCREDIST] stderr: {stderr}")
+
             if result.returncode in (0, 3010):
                 logging.info(f"[VCREDIST] {filename} installed successfully")
             else:
@@ -375,7 +360,6 @@ def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     env = _clean_pyinstaller_env(os.environ.copy())
     env["GAMEID"] = linux_config.get("umu_id") or "umu-default"
     env["WINEPREFIX"] = prefix_path
-    env["STEAM_COMPAT_DATA_PATH"] = linux_config["compat_data"]
 
     # optional PROTONPATH - if empty, umu-run uses UMU-Proton
     if linux_config.get("proton_path"):
@@ -388,7 +372,7 @@ def launch_with_umu(exe_path, linux_config, game_launch_cmd=None):
     if game_launch_cmd:
         cmd.extend(game_launch_cmd.split())
 
-    install_vcredist(prefix_path, proton_path=linux_config.get("proton_path"))
+    install_vcredist(prefix_path, env, umu_bin=umu_bin)
 
     game_dir = os.path.dirname(exe_path)
 


### PR DESCRIPTION
Some games require the Microsoft Visual C++ 2015-2022 redistributables to run under Wine/Proton. This installs both x86 and x64 versions silently on the first launch using the official Microsoft URLs, with a marker file to skip reinstallation on subsequent launches.