### PR TITLE
Add FileDitch as manual download provider

### DIFF
--- a/binaries/AscendaraLocalRefresh/src/steamrip_scraper.py
+++ b/binaries/AscendaraLocalRefresh/src/steamrip_scraper.py
@@ -461,6 +461,8 @@ class SteamRIPScraper(BaseScraper):
                 download_links.setdefault("datanodes", []).append(href)
             elif "1fichier.com" in href:
                 download_links.setdefault("1fichier", []).append(href)
+            elif "fileditchfiles.me" in href or "fileditch.com" in href:
+                download_links.setdefault("fileditch", []).append(href)
         
         return download_links
     

--- a/src/config/providers.js
+++ b/src/config/providers.js
@@ -30,6 +30,8 @@ export const PROVIDER_DISPLAY_NAMES = {
   qiwi: "Qiwi",
   vikingfile: "VikingFile",
   torrent: "Torrent",
+  fileditch: "FileDitch",
+  fileditchfiles: "FileDitch",
 };
 
 // TorBox display-name mapping (TorBox API uses slightly different casing).
@@ -58,6 +60,8 @@ export const PROVIDER_DOMAINS = {
   datanodes: ["datanodes.to"],
   qiwi: ["qiwi.gg"],
   vikingfile: ["vikingfile.com"],
+  fileditch: ["fileditchfiles.me", "fileditch.com"],
+  fileditchfiles: ["fileditchfiles.me"],
 };
 
 /**

--- a/src/pages/Download.jsx
+++ b/src/pages/Download.jsx
@@ -94,6 +94,11 @@ import {
   TORBOX_PROVIDER_DISPLAY_NAMES,
 } from "@/config/providers";
 
+const LOCAL_FALLBACK_PATTERNS = {
+  fileditch: /https?:\/\/(fileditchfiles\.me|fileditch\.com)\/file\.php\?f=.+/i,
+  fileditchfiles: /https?:\/\/(fileditchfiles\.me|fileditch\.com)\/file\.php\?f=.+/i,
+};
+
 // Async validation using API patterns
 const isValidURL = async (url, provider, patterns) => {
   const trimmedUrl = url.trim();
@@ -101,7 +106,7 @@ const isValidURL = async (url, provider, patterns) => {
     return true;
   }
   if (!patterns) return false;
-  const pattern = getProviderPattern(provider, patterns);
+  const pattern = getProviderPattern(provider, patterns) || LOCAL_FALLBACK_PATTERNS[provider] || null;
   if (!pattern) return false;
   return pattern.test(trimmedUrl);
 };
@@ -2728,6 +2733,10 @@ export default function DownloadPage() {
                             case "datanodes":
                               displayName = "DataNodes";
                               break;
+                            case "fileditch":
+                            case "fileditchfiles":
+                              displayName = "FileDitch";
+                              break;
                             default:
                               displayName =
                                 provider.charAt(0).toUpperCase() + provider.slice(1);
@@ -2838,6 +2847,10 @@ export default function DownloadPage() {
                                   break;
                                 case "datanodes":
                                   displayName = "DataNodes";
+                                  break;
+                                case "fileditch":
+                                case "fileditchfiles":
+                                  displayName = "FileDitch";
                                   break;
                                 default:
                                   displayName =


### PR DESCRIPTION
FileDitch uses cloudflare turnstile, so seamless download is not possible. Added as manual only.