### PR TITLE
fix: support qBittorrent WebUI authentication bypass

### DIFF
--- a/electron/modules/ipc-handlers.js
+++ b/electron/modules/ipc-handlers.js
@@ -1344,6 +1344,7 @@ function registerMiscHandlers() {
         "adminadmin";
       const { origin, baseURL } = resolveQbitEndpoint(credentials);
       qbittorrentBaseUrl = origin;
+      qbittorrentSID = null;
 
       const response = await axios.post(
         `${baseURL}/auth/login`,
@@ -1364,10 +1365,12 @@ function registerMiscHandlers() {
       }
 
       const setCookie = response.headers["set-cookie"];
-      if (setCookie && setCookie[0]) {
-        const match = setCookie[0].match(/SID=([^;]+)/);
+      const cookies = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : [];
+      for (const cookie of cookies) {
+        const match = cookie.match(/(?:^|;\s*)SID=([^;]+)/i);
         if (match) {
           qbittorrentSID = match[1];
+          break;
         }
       }
 
@@ -1379,16 +1382,16 @@ function registerMiscHandlers() {
 
   ipcMain.handle("qbittorrent:version", async () => {
     try {
-      if (!qbittorrentSID) {
-        throw new Error("No SID available - please login first");
-      }
       const origin = qbittorrentBaseUrl || resolveQbitEndpoint().origin;
+      const headers = {
+        Referer: origin,
+        Origin: origin,
+      };
+      if (qbittorrentSID) {
+        headers.Cookie = `SID=${qbittorrentSID}`;
+      }
       const response = await axios.get(`${origin}/api/v2/app/version`, {
-        headers: {
-          Referer: origin,
-          Origin: origin,
-          Cookie: `SID=${qbittorrentSID}`,
-        },
+        headers,
         withCredentials: true,
         timeout: 5000,
       });


### PR DESCRIPTION
## Summary

- allow qBittorrent status checks when WebUI authentication bypass succeeds without issuing an SID
- clear stale session state before each login and handle both string and array `set-cookie` headers
- attach the SID cookie to version requests only when qBittorrent provides one

## Problem

When qBittorrent's localhost or subnet authentication bypass is enabled, `/api/v2/auth/login` can succeed without returning an SID cookie. Ascendara reports the login as successful, but then rejects the version request with:

`No SID available - please login first`

The version endpoint is accessible without a cookie in this configuration.

## Verification

- `node --check electron/modules/ipc-handlers.js`
- production Vite build
- qBittorrent v5.2.3 integration:
  - login returned HTTP 204 without an SID
  - version request without a cookie returned HTTP 200 and `v5.2.3`
